### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -5834,7 +5834,7 @@ static int zipfileUpdate(
         zFree = sqlite3_mprintf("%s/", zPath);
         if( zFree==0 ){ rc = SQLITE_NOMEM; }
         zPath = (const char*)zFree;
-        nPath++;
+        nPath = (int)strlen(zPath);
       }
     }
 
@@ -6235,11 +6235,11 @@ void zipfileStep(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal){
   }else{
     if( zName[nName-1]!='/' ){
       zName = zFree = sqlite3_mprintf("%s/", zName);
-      nName++;
       if( zName==0 ){
         rc = SQLITE_NOMEM;
         goto zipfile_step_out;
       }
+      nName = (int)strlen(zName);
     }else{
       while( nName>1 && zName[nName-2]=='/' ) nName--;
     }


### PR DESCRIPTION
Hi Litetree Team,

Our tool identified a potential vulnerability in a clone function `zipfileStep()` in `shell.c` sourced from [sqlite/sqlite](https://github.com/sqlite/sqlite). These issues, originally reported in [CVE-2019-19959](https://nvd.nist.gov/vuln/detail/CVE-2019-19959), were resolved in the repository via this commit https://github.com/sqlite/sqlite/commit/d8f2d46cbc9925e034a68aaaf60aad788d9373c1.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.